### PR TITLE
adjustments for side A styles/css files

### DIFF
--- a/styles/side-a/components/hero.css
+++ b/styles/side-a/components/hero.css
@@ -317,10 +317,10 @@
     right: -90px;
   }
 
-  .hero-blob1 {
-    /* width: 15%; */
-    /* left: -80px; */
-  }
+  /* .hero-blob1 {
+    width: 15%;
+    left: -80px;
+  } */
 
   .hero-character1 {
     /* top: -10px; */

--- a/styles/side-a/components/navbar.css
+++ b/styles/side-a/components/navbar.css
@@ -11,7 +11,7 @@
   background: #f05f7d;
   box-shadow: 0px 10px 20px rgba(0, 0, 0, 0.25);
   padding: 25px 40px;
-  transition: transform 0.7s cubic-bezier(0.4, 0, 0.2, 1);
+  transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 .navbar-container {
@@ -161,8 +161,8 @@
   top: calc(100% + 12px);
   left: 50%;
   transform: translateX(-50%);
-  background: rgba(17, 3, 73, 0.95);
-  color: #fff5db;
+  background: #561487;
+  color: #F3F3F3;
   padding: 8px 16px;
   border-radius: 100px;
   font-family: "Sora", sans-serif;
@@ -183,7 +183,7 @@
   left: 50%;
   transform: translateX(-50%);
   border: 6px solid transparent;
-  border-bottom-color: rgba(17, 3, 73, 0.95);
+  border-bottom-color: #561487;
 }
 
 .toggle-switch-wrapper:hover .toggle-tooltip {

--- a/styles/side-a/components/prev-embarks.css
+++ b/styles/side-a/components/prev-embarks.css
@@ -13,7 +13,7 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  background-color: #fff5db;
+  background: linear-gradient(180deg, #f4f1b8 0%, #fff5db 24.04%);
   position: relative;
   overflow: visible;
   text-align: center;

--- a/styles/side-a/components/readnow2.css
+++ b/styles/side-a/components/readnow2.css
@@ -1,8 +1,8 @@
-/* READ NOW 2 */
+/* READ NOW 2 - BASE STYLES */
 
 /* IFRAME */
 .iframe-container {
-  margin-top: 5svh;
+  margin-top: 5vh;
   left: 50%;
   transform: translateX(-50%);
   position: relative;
@@ -22,7 +22,6 @@
 }
 
 /* SPHERE */
-
 .decor2-container {
   position: absolute;
   right: 50%;
@@ -54,7 +53,7 @@
 
 #boat {
   width: 30vw;
-  left: -5%;
+  left: -11%;
   top: 50%;
   z-index: 2;
 }
@@ -88,11 +87,9 @@
   opacity: 0;
   transition: all 1.5s ease;
   transform: scale(0.9);
-
-  /* Text styles */
   font-family: "Poppins", sans-serif;
   font-style: normal;
-  font-weight: 400;
+  font-weight: 600;
   font-size: 22px;
   line-height: 33px;
   text-align: center;
@@ -133,8 +130,6 @@
   cursor: pointer;
   border-radius: 100px;
   box-shadow: 0px 10px 15px rgba(0, 0, 0, 0.25);
-
-  /* Button sizing */
   display: flex;
   flex-direction: row;
   align-items: center;
@@ -143,8 +138,6 @@
   height: 53px;
   padding: 0px;
   gap: 7px;
-
-  /* Text styles */
   font-family: "Poppins", sans-serif;
   font-style: normal;
   font-weight: 500;
@@ -152,7 +145,6 @@
   line-height: 30px;
   text-align: center;
   color: #f3f3f3;
-
   opacity: 0;
   transition: all 1.5s ease, background 0.3s ease;
   transform: scale(0.9);
@@ -191,387 +183,15 @@
   }
 }
 
-/* MEDIA QUERIES RESPONSIVE  */
+/* RESPONSIVE BREAKPOINTS */
 
-/* Large Desktops (1920px+) */
-@media (min-width: 1920px) {
-  .iframe-container {
-    width: 65%;
-    height: 65%;
-    margin-top: 3vh;
-  }
-
-  .decor2-sphere {
-    width: 220vmin;
-  }
-
-  #boat,
-  #footprint {
-    width: 25vw;
-  }
-
-  .readnow2-title {
-    font-size: 26px;
-    line-height: 39px;
-  }
-
-  .embark-logo-inline {
-    height: 32px;
-    padding-bottom: 6px;
-  }
-
-  .readnow2-text {
-    font-size: 22px;
-    width: 280px;
-    height: 56px;
-  }
-}
-
-/* Standard Desktops (1440px - 1919px) */
-@media (min-width: 1440px) and (max-width: 1919px) {
-  .iframe-container {
-    width: 68%;
-    height: 68%;
-    margin-top: 4vh;
-  }
-
-  .decor2-sphere {
-    width: 240vmin;
-  }
-
-  .readnow2-title {
-    font-size: 24px;
-    line-height: 36px;
-  }
-
-  .embark-logo-inline {
-    height: 29px;
-    padding-bottom: 5px;
-  }
-
-  .readnow2-text {
-    font-size: 21px;
-    width: 270px;
-    height: 54px;
-  }
-}
-
-/* Laptops (1280px - 1439px) */
-@media (min-width: 1280px) and (max-width: 1439px) {
-  .iframe-container {
-    width: 70%;
-    height: 70%;
-    margin-top: 5vh;
-  }
-
-  .decor2-sphere {
-    width: 250vmin;
-  }
-
-  .readnow2-title {
-    font-size: 22px;
-    line-height: 33px;
-  }
-
-  .embark-logo-inline {
-    height: 22px;
-  }
-}
-
-/* Tablets Portrait (768px - 1023px) */
-@media (max-width: 768px) {
-  .iframe-container {
-    margin-top: 6vh;
-    width: 80%;
-    height: auto;
-    max-height: 55vh;
-    padding-top: 42%;
-    overflow: hidden;
-  }
-
-  .iframe-container iframe {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-  }
-
-  .decor2-sphere {
-    width: 320vmin;
-    top: 75%;
-  }
-
-  #boat,
-  #footprint {
-    width: 38vw;
-  }
-
-  #boat {
-    left: -5%;
-    top: 55%;
-    rotate: -2deg;
-  }
-
-  #footprint {
-    right: -5%;
-    top: 68%;
-    rotate: 2deg;
-  }
-
-  .readnow-content-wrapper {
-    position: absolute;
-    top: auto;
-    bottom: auto;
-    margin-top: 8vh;
-    transform: translate(-50%, 0);
-    top: calc(6vh + 42vw + 8vh);
-  }
-
-  .readnow2-title {
-    max-width: 88%;
-    font-size: 18px;
-    line-height: 27px;
-    padding: 0 20px;
-    gap: 6px;
-  }
-
-  .embark-logo-inline {
-    height: 18px;
-  }
-
-  .readnow2-text {
-    font-size: 16px;
-    width: 230px;
-    height: 48px;
-  }
-}
-
-/* Small Tablets Portrait (600px - 767px) */
-@media (min-width: 600px) and (max-width: 767px) and (orientation: portrait) {
-  .iframe-container {
-    margin-top: 7vh;
-    width: 84%;
-    height: auto;
-    max-height: 52vh;
-    padding-top: 44%;
-    overflow: hidden;
-  }
-
-  .iframe-container iframe {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-  }
-
-  .decor2-sphere {
-    width: 350vmin;
-    top: 77%;
-  }
-
-  #boat,
-  #footprint {
-    width: 42vw;
-  }
-
-  #boat {
-    left: -8%;
-    top: 56%;
-    rotate: -2.5deg;
-  }
-
-  #footprint {
-    right: -7%;
-    top: 68%;
-    rotate: 2.5deg;
-  }
-
-  .readnow-content-wrapper {
-    position: absolute;
-    top: auto;
-    bottom: auto;
-    margin-top: 8vh;
-    transform: translate(-50%, 0);
-    top: calc(7vh + 44vw + 8vh);
-  }
-
-  .readnow2-title {
-    max-width: 90%;
-    font-size: 17px;
-    line-height: 25px;
-    padding: 0 18px;
-    gap: 5px;
-  }
-
-  .embark-logo-inline {
-    height: 17px;
-  }
-
-  .readnow2-text {
-    font-size: 15px;
-    width: 215px;
-    height: 46px;
-  }
-}
-
-/* Medium Mobile (480px - 599px) */
-@media (min-width: 425px) and (max-width: 599px) {
-  .iframe-container {
-    margin-top: 8vh;
-    width: 88%;
-    height: auto;
-    max-height: 48vh;
-    padding-top: 45%;
-    overflow: hidden;
-  }
-
-  .iframe-container iframe {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-  }
-
-  .decor2-sphere {
-    width: 400vmin;
-    top: 80%;
-  }
-
-  #boat,
-  #footprint {
-    width: 50vw;
-  }
-
-  #boat {
-    left: -12%;
-    top: 58%;
-    rotate: -3deg;
-  }
-
-  #footprint {
-    right: -10%;
-    top: 66%;
-    rotate: 3deg;
-  }
-
-  .readnow-content-wrapper {
-    position: absolute;
-    top: auto;
-    bottom: auto;
-    margin-top: 7vh;
-    transform: translate(-50%, 0);
-    top: calc(8vh + 45vw + 7vh);
-  }
-
-  .readnow2-title {
-    max-width: 92%;
-    font-size: 15px;
-    line-height: 22px;
-    padding: 0 18px;
-    gap: 4px;
-  }
-
-  .embark-logo-inline {
-    height: 15px;
-    padding-bottom: 2px;
-  }
-
-  .readnow2-text {
-    font-size: 14px;
-    width: 200px;
-    height: 44px;
-  }
-}
-
-/* Small Mobile (376px - 479px) */
-@media (min-width: 376px) and (max-width: 479px) {
-  .iframe-container {
-    margin-top: 10vh;
-    width: 90%;
-    height: auto;
-    max-height: 45vh;
-    padding-top: 48%;
-    overflow: hidden;
-  }
-
-  .iframe-container iframe {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-  }
-
-  .decor2-sphere {
-    width: 450vmin;
-    top: 82%;
-  }
-
-  #boat,
-  #footprint {
-    width: 55vw;
-  }
-
-  #boat {
-    left: -15%;
-    top: 56%;
-    rotate: -5deg;
-  }
-
-  #footprint {
-    right: -12%;
-    top: 64%;
-    rotate: 5deg;
-  }
-
-  .readnow-content-wrapper {
-    position: absolute;
-    top: auto;
-    bottom: auto;
-    margin-top: 6vh;
-    transform: translate(-50%, 0);
-    top: calc(10vh + 48vw + 6vh);
-  }
-
-  .readnow2-title {
-    max-width: 94%;
-    font-size: 14px;
-    line-height: 21px;
-    padding: 0 15px;
-    gap: 4px;
-  }
-
-  .embark-logo-inline {
-    height: 14px;
-  }
-
-  .readnow2-text {
-    font-size: 13px;
-    width: 190px;
-    height: 42px;
-  }
-}
-
-/* Extra Small Mobile (320px - 375px) */
-@media (min-width: 320px) and (max-width: 375px) {
+/* Mobile S: 320px - 374px */
+@media (max-width: 374px) {
   .iframe-container {
     margin-top: 12vh;
     width: 92%;
-    height: auto;
-    max-height: 42vh;
     padding-top: 50%;
-    overflow: hidden;
-  }
-
-  .iframe-container iframe {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
+    max-height: 42vh;
   }
 
   .decor2-sphere {
@@ -579,30 +199,25 @@
     top: 85%;
   }
 
-  #boat,
-  #footprint {
-    width: 60vw;
-  }
-
   #boat {
+    width: 60vw;
     left: -18%;
-    top: 54%;
+    top: 70%;
     rotate: -6deg;
   }
 
   #footprint {
+    width: 60vw;
     right: -15%;
-    top: 62%;
+    top: 80%;
     rotate: 6deg;
   }
 
   .readnow-content-wrapper {
-    position: absolute;
-    top: auto;
+    top: calc(12vh + 50vw + 10vh);
     bottom: auto;
-    margin-top: 6vh;
-    transform: translate(-50%, 0);
-    top: calc(12vh + 50vw + 6vh);
+    margin-top: 10vh;
+    gap: 12px;
   }
 
   .readnow2-title {
@@ -624,92 +239,380 @@
   }
 }
 
-/* Very Small Mobile (<320px) */
-@media (max-width: 319px) {
+/* Mobile M: 375px - 424px */
+@media (min-width: 375px) and (max-width: 424px) {
   .iframe-container {
-    margin-top: 14vh;
-    width: 94%;
-    height: auto;
-    max-height: 40vh;
-    padding-top: 52%;
-    overflow: hidden;
-  }
-
-  .iframe-container iframe {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
+    margin-top: 10vh;
+    width: 90%;
+    padding-top: 48%;
+    max-height: 45vh;
   }
 
   .decor2-sphere {
-    width: 550vmin;
-    top: 88%;
+    width: 450vmin;
+    top: 82%;
+  }
+
+  #boat {
+    width: 55vw;
+    left: -15%;
+    top: 70%;
+    rotate: -5deg;
+  }
+
+  #footprint {
+    width: 55vw;
+    right: -12%;
+    top: 80%;
+    rotate: 5deg;
+  }
+
+  .readnow-content-wrapper {
+    top: calc(10vh + 48vw + 10vh);
+    bottom: auto;
+    margin-top: 10vh;
+    gap: 12px;
+  }
+
+  .readnow2-title {
+    max-width: 94%;
+    font-size: 14px;
+    line-height: 21px;
+    padding: 0 15px;
+    gap: 4px;
+  }
+
+  .embark-logo-inline {
+    height: 14px;
+  }
+
+  .readnow2-text {
+    font-size: 13px;
+    width: 190px;
+    height: 42px;
+  }
+}
+
+/* Mobile L: 425px - 767px */
+@media (min-width: 425px) and (max-width: 767px) {
+  .iframe-container {
+    margin-top: 8vh;
+    width: 88%;
+    padding-top: 45%;
+    max-height: 48vh;
+  }
+
+  .decor2-sphere {
+    width: 400vmin;
+    top: 80%;
+  }
+
+  #boat {
+    width: 50vw;
+    left: -12%;
+    top: 70%;
+    rotate: -3deg;
+  }
+
+  #footprint {
+    width: 50vw;
+    right: -10%;
+    top: 80%;
+    rotate: 3deg;
+  }
+
+  .readnow-content-wrapper {
+    top: calc(8vh + 45vw + 11vh);
+    bottom: auto;
+    margin-top: 11vh;
+    gap: 12px;
+  }
+
+  .readnow2-title {
+    max-width: 92%;
+    font-size: 16px;
+    line-height: 24px;
+    padding: 0 18px;
+    gap: 5px;
+  }
+
+  .embark-logo-inline {
+    height: 16px;
+    padding-bottom: 2px;
+  }
+
+  .readnow2-text {
+    font-size: 14px;
+    width: 210px;
+    height: 46px;
+  }
+}
+
+/* Tablet: 768px - 1023px */
+@media (min-width: 768px) and (max-width: 1023px) {
+  .iframe-container {
+    margin-top: 6vh;
+    width: 80%;
+    padding-top: 42%;
+    max-height: 55vh;
+  }
+
+  .decor2-sphere {
+    width: 320vmin;
+    top: 75%;
+  }
+
+  #boat {
+    width: 38vw;
+    left: -5%;
+    top: 55%;
+    rotate: -2deg;
+  }
+
+  #footprint {
+    width: 38vw;
+    right: -5%;
+    top: 68%;
+    rotate: 2deg;
+  }
+
+  .readnow-content-wrapper {
+    bottom: 4%;
+    gap: 12px;
+  }
+
+  .readnow2-title {
+    max-width: 88%;
+    font-size: 18px;
+    line-height: 27px;
+    padding: 0 20px;
+    gap: 6px;
+  }
+
+  .embark-logo-inline {
+    height: 18px;
+  }
+
+  .readnow2-text {
+    font-size: 16px;
+    width: 230px;
+    height: 48px;
+  }
+}
+
+/* Laptop: 1024px - 1439px */
+@media (min-width: 1024px) and (max-width: 1439px) {
+  .iframe-container {
+    width: 70%;
+    margin-top: 5vh;
+  }
+
+  .decor2-sphere {
+    width: 250vmin;
+  }
+
+  .readnow2-title {
+    font-size: 22px;
+    line-height: 33px;
+  }
+
+  .embark-logo-inline {
+    height: 22px;
+  }
+}
+
+/* Laptop L: 1440px - 1919px */
+@media (min-width: 1440px) and (max-width: 1919px) {
+  .iframe-container {
+    width: 68%;
+    margin-top: 4vh;
+  }
+
+  .decor2-sphere {
+    width: 240vmin;
+  }
+
+  .readnow2-title {
+    font-size: 24px;
+    line-height: 36px;
+  }
+
+  .embark-logo-inline {
+    height: 26px;
+    padding-bottom: 5px;
+  }
+
+  .readnow2-text {
+    font-size: 21px;
+    width: 270px;
+    height: 54px;
   }
 
   #boat,
   #footprint {
-    width: 65vw;
-  }
-
-  #boat {
-    left: -20%;
-    top: 52%;
-    rotate: -7deg;
-  }
-
-  #footprint {
-    right: -18%;
-    top: 60%;
-    rotate: 7deg;
-  }
-
-  .readnow-content-wrapper {
-    position: absolute;
-    top: auto;
-    bottom: auto;
-    margin-top: 6vh;
-    transform: translate(-50%, 0);
-    top: calc(14vh + 52vw + 6vh);
-  }
-
-  .readnow2-title {
-    max-width: 96%;
-    font-size: 12px;
-    line-height: 18px;
-    padding: 0 10px;
-    gap: 3px;
-  }
-
-  .embark-logo-inline {
-    height: 12px;
-  }
-
-  .readnow2-text {
-    font-size: 11px;
-    width: 170px;
-    height: 38px;
+    width: 28vw;
   }
 }
 
-/* Landscape Orientation Adjustments */
-@media (max-height: 600px) and (orientation: landscape) {
+/* 4K: 1920px - 2559px */
+@media (min-width: 1920px) and (max-width: 2559px) {
+  .iframe-container {
+    width: 65%;
+    margin-top: 3vh;
+  }
+
+  .decor2-sphere {
+    width: 220vmin;
+  }
+
+  .readnow2-title {
+    font-size: 26px;
+    line-height: 39px;
+  }
+
+  .embark-logo-inline {
+    height: 28px;
+    padding-bottom: 6px;
+  }
+
+  .readnow2-text {
+    font-size: 22px;
+    width: 280px;
+    height: 56px;
+  }
+
+  #boat,
+  #footprint {
+    width: 25vw;
+  }
+}
+
+/* 4K+: 2560px+ */
+@media (min-width: 2560px) {
+  .iframe-container {
+    width: 60%;
+    margin-top: 2vh;
+  }
+
+  .decor2-sphere {
+    width: 200vmin;
+  }
+
+  .readnow2-title {
+    font-size: 28px;
+    line-height: 42px;
+  }
+
+  .embark-logo-inline {
+    height: 30px;
+    padding-bottom: 6px;
+  }
+
+  .readnow2-text {
+    font-size: 24px;
+    width: 300px;
+    height: 60px;
+  }
+
+  #boat,
+  #footprint {
+    width: 22vw;
+  }
+}
+
+/* LANDSCAPE ORIENTATION ADJUSTMENTS */
+
+/* Mobile Landscape: < 768px */
+@media (max-width: 767px) and (orientation: landscape) and (max-height: 500px) {
+  .iframe-container {
+    margin-top: clamp(6vh, 8vh, 10vh);
+    width: 72%;
+    padding-top: 34%;
+    max-height: 52vh;
+  }
+
+  .readnow-content-wrapper {
+    bottom: 6%;
+    gap: 8px;
+  }
+
+  .readnow2-title {
+    font-size: 14px;
+    line-height: 21px;
+    max-width: 85%;
+  }
+
+  .embark-logo-inline {
+    height: 14px;
+  }
+
+  .readnow2-text {
+    font-size: 13px;
+    width: 190px;
+    height: 40px;
+  }
+
+  #boat,
+  #footprint {
+    width: 28vw;
+    top: 45%;
+  }
+}
+
+/* Tablet Landscape: 768px - 1024px */
+@media (min-width: 768px) and (max-width: 1024px) and (orientation: landscape) and (max-height: 768px) {
+  .iframe-container {
+    margin-top: clamp(3vh, 4vh, 5vh);
+    width: 70%;
+    padding-top: 32%;
+    max-height: 58vh;
+  }
+
+  .decor2-sphere {
+    width: 280vmin;
+    top: 72%;
+  }
+
+  #boat {
+    width: 28vw;
+    left: 0%;
+    top: 50%;
+  }
+
+  #footprint {
+    width: 28vw;
+    right: 0%;
+    top: 65%;
+  }
+
+  .readnow-content-wrapper {
+    bottom: 5%;
+    gap: 10px;
+  }
+
+  .readnow2-title {
+    font-size: 16px;
+    line-height: 24px;
+  }
+
+  .embark-logo-inline {
+    height: 16px;
+  }
+
+  .readnow2-text {
+    font-size: 15px;
+    width: 210px;
+    height: 44px;
+  }
+}
+
+/* General Low Height Landscape */
+@media (max-height: 600px) and (orientation: landscape) and (min-width: 768px) {
   .iframe-container {
     margin-top: clamp(4vh, 5vh, 6vh);
     width: 68%;
-    height: auto;
-    max-height: 55vh;
     padding-top: 28%;
-    overflow: hidden;
-  }
-
-  .iframe-container iframe {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
+    max-height: 55vh;
   }
 
   .readnow-content-wrapper {
@@ -745,112 +648,5 @@
 
   #footprint {
     right: 2%;
-  }
-}
-
-/* Tablet Landscape (768px - 1024px) */
-@media (min-width: 768px) and (max-width: 1024px) and (orientation: landscape) and (max-height: 768px) {
-  .iframe-container {
-    margin-top: clamp(3vh, 4vh, 5vh);
-    width: 70%;
-    height: auto;
-    max-height: 58vh;
-    padding-top: 32%;
-    overflow: hidden;
-  }
-
-  .iframe-container iframe {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-  }
-
-  .decor2-sphere {
-    width: 280vmin;
-    top: 72%;
-  }
-
-  #boat,
-  #footprint {
-    width: 28vw;
-  }
-
-  #boat {
-    left: 0%;
-    top: 50%;
-  }
-
-  #footprint {
-    right: 0%;
-    top: 65%;
-  }
-
-  .readnow-content-wrapper {
-    bottom: 5%;
-    gap: 10px;
-  }
-
-  .readnow2-title {
-    font-size: 16px;
-    line-height: 24px;
-  }
-
-  .embark-logo-inline {
-    height: 16px;
-  }
-
-  .readnow2-text {
-    font-size: 15px;
-    width: 210px;
-    height: 44px;
-  }
-}
-
-/* Mobile Landscape */
-@media (max-width: 767px) and (orientation: landscape) and (max-height: 500px) {
-  .iframe-container {
-    margin-top: clamp(6vh, 8vh, 10vh);
-    width: 72%;
-    height: auto;
-    max-height: 52vh;
-    padding-top: 34%;
-    overflow: hidden;
-  }
-
-  .iframe-container iframe {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-  }
-
-  .readnow-content-wrapper {
-    bottom: 6%;
-    gap: 8px;
-  }
-
-  .readnow2-title {
-    font-size: 14px;
-    line-height: 21px;
-    max-width: 85%;
-  }
-
-  .embark-logo-inline {
-    height: 14px;
-  }
-
-  .readnow2-text {
-    font-size: 13px;
-    width: 190px;
-    height: 40px;
-  }
-
-  #boat,
-  #footprint {
-    width: 28vw;
-    top: 45%;
   }
 }

--- a/styles/side-a/pages/about-ad-astra.css
+++ b/styles/side-a/pages/about-ad-astra.css
@@ -11,7 +11,7 @@ body,
 html {
   margin: 0;
   padding: 0;
-  overflow: hidden;
+  overflow-x: hidden;
   width: 100%;
   height: 100%;
   zoom: reset;
@@ -23,14 +23,11 @@ html {
 
 /* MAIN CONTAINER & BACKGROUND */
 .about-ad-astra {
-  position: fixed;
-  top: 0;
-  left: 0;
+  position: relative;
   width: 100vw;
   height: 100vh;
   background: linear-gradient(180deg, #fff5db 21.63%, #ff60d7 100%);
   background-size: 100% 100%;
-  background-attachment: fixed;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -212,7 +209,7 @@ html {
   background: transparent;
   border: none;
   cursor: pointer;
-  z-index: 15; /* Above everything else */
+  z-index: 15;
   transition: all 0.2s ease;
   outline: none !important;
   -webkit-tap-highlight-color: transparent;

--- a/styles/side-a/pages/about-decorative-assets.css
+++ b/styles/side-a/pages/about-decorative-assets.css
@@ -1,7 +1,7 @@
 /* (SIDE A) DESKTOP DECORATIVE ASSETS */
 
 .pinwheel-swirl {
-  position: fixed;
+  position: absolute;
   left: -50px;
   top: 25%;
   transform: translateY(-50%);
@@ -14,7 +14,7 @@
 }
 
 .wave {
-  position: fixed;
+  position: absolute;
   bottom: -50px;
   left: 50%;
   transform: translateX(-50%);
@@ -27,7 +27,7 @@
 }
 
 .about-girl {
-  position: fixed;
+  position: absolute;
   bottom: -50px;
   right: 0;
   width: auto;
@@ -41,7 +41,7 @@
 /* MOBILE DECORATIVE ASSETS */
 
 .mobile-bottom-assets {
-  position: fixed;
+  position: absolute;
   bottom: -200px;
   left: 0;
   width: 100vw;
@@ -262,7 +262,7 @@
     height: 70vh;
     width: 100vw;
     bottom: -200px;
-    position: fixed;
+    position: absolute;
   }
 }
 
@@ -272,7 +272,7 @@
     height: 60vh;
     width: 100vw;
     bottom: -180px;
-    position: fixed;
+    position: absolute;
   }
 }
 

--- a/styles/side-a/pages/credits.css
+++ b/styles/side-a/pages/credits.css
@@ -33,7 +33,7 @@ html {
 }
 
 .credits-ad-astra {
-  position: fixed;
+  position: relative;
   top: 0;
   left: 0;
   width: 100vw;
@@ -1120,7 +1120,7 @@ html {
 /* MOBILE DECORATIVE ASSETS */
 
 .mobile-bottom-assets {
-  position: fixed;
+  position: relative;
   bottom: -200px;
   left: 0;
   width: 100vw;

--- a/styles/side-a/pages/pre-readnow.css
+++ b/styles/side-a/pages/pre-readnow.css
@@ -11,7 +11,7 @@ body,
 html {
   margin: 0;
   padding: 0;
-  overflow: hidden;
+  overflow-x: hidden;
   width: 100%;
   height: 100%;
   zoom: reset;
@@ -23,19 +23,17 @@ html {
 
 /* MAIN CONTAINER & BACKGROUND */
 .pre-readnow {
-  position: fixed;
-  top: 0;
-  left: 0;
+  position: relative;
   width: 100vw;
   height: 100vh;
   background: linear-gradient(
     180deg,
-    #e3ed6a 0%,
+    #e3ed6a 20%,
     rgba(255, 245, 219, 0.9) 50%,
-    #e5ec8a 100%
+    #F0EFAA 100%
   );
   background-size: 100% 100%;
-  background-attachment: fixed;
+  background-attachment: absolute;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -211,10 +209,6 @@ html {
 
   .content-container {
     padding: clamp(80px, 8vh, 120px) clamp(60px, 4vw, 100px);
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
     width: auto;
     height: auto;
     max-width: 90vw;
@@ -325,27 +319,6 @@ html {
   animation: textFadeIn 1s cubic-bezier(0.25, 0.46, 0.45, 0.94) 0.6s forwards;
 }
 
-/* ANIMATION OVERRIDE FOR 2560px+ */
-@media (min-width: 2560px) {
-  .content-container {
-    opacity: 0;
-    transform: translate(-50%, -50%) translateY(30px);
-    animation: contentFadeInCentered 1.2s cubic-bezier(0.25, 0.46, 0.45, 0.94)
-      0.3s forwards;
-  }
-
-  @keyframes contentFadeInCentered {
-    0% {
-      opacity: 0;
-      transform: translate(-50%, -50%) translateY(30px);
-    }
-    100% {
-      opacity: 1;
-      transform: translate(-50%, -50%) translateY(0);
-    }
-  }
-}
-
 /* Entry animation keyframes */
 @keyframes contentFadeIn {
   0% {
@@ -375,12 +348,7 @@ html {
   .main-text {
     animation: none !important;
     opacity: 1 !important;
-  }
-
-  @media (min-width: 2560px) {
-    .content-container {
-      transform: translate(-50%, -50%) !important;
-    }
+    transform: none !important;
   }
 }
 
@@ -423,10 +391,6 @@ html {
 /* EXTRA WIDE SCREENS IN LANDSCAPE */
 @media (min-width: 3840px) {
   .content-container {
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
     width: auto;
     height: auto;
     max-width: 85vw;
@@ -438,27 +402,5 @@ html {
     line-height: clamp(10rem, 6.5vw, 17rem);
     margin: 0 auto;
     text-align: center;
-  }
-
-  .content-container {
-    animation: contentFadeInCentered 1.2s cubic-bezier(0.25, 0.46, 0.45, 0.94)
-      0.3s forwards;
-  }
-}
-
-/* ZOOM COMPATIBILITY FOR LARGE SCREENS */
-@media (min-width: 2560px) {
-  .pre-readnow {
-    min-width: 100vw;
-    min-height: 100vh;
-  }
-
-  .content-container {
-    position: fixed;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    width: fit-content;
-    height: fit-content;
   }
 }


### PR DESCRIPTION
**Adjustments for SIDE A Integrations in styles/css files:**
- hero, navbar, prev-embarks, readnow2, about-ad-astra, about-decorative-assets, credits, and pre-readnow

<img width="1159" height="248" alt="image" src="https://github.com/user-attachments/assets/9001a5bc-5b60-48b8-b45e-0964d1aea06f" />
