### PR TITLE
adjustments for SIDE B styles/css files

### DIFF
--- a/styles/side-b/components/hero.css
+++ b/styles/side-b/components/hero.css
@@ -11,7 +11,6 @@
   width: 100vw;
   position: relative;
   overflow: hidden;
-  /* transform: scale(1); */
 }
 
 /* CONTENT CSS */
@@ -27,7 +26,8 @@
 
 .hero-EMBARK {
   width: 50%;
-  /* fill: white; */
+  margin: 0;
+  padding: 0;
 }
 
 .hero-Vol11 {
@@ -36,6 +36,8 @@
   color: white;
   text-shadow: 0px 10px 15px rgba(0, 0, 0, 0.25);
   font-weight: 800;
+  margin: 0;
+  padding: 0;
 }
 
 /* BUTTON CSS */
@@ -45,7 +47,7 @@
   align-items: center;
   justify-content: center;
   padding: 0px;
-  gap: 12px;
+  gap: 7px;
 
   width: 220px;
   height: 43px;
@@ -65,8 +67,6 @@
   font-style: normal;
   font-weight: 500;
   font-size: 16px;
-  /* line-height: 30px; */
-  /* identical to box height */
   text-align: center;
 
   color: white;
@@ -90,12 +90,7 @@
   color: white;
 }
 
-/* Hover v1 */
-/* .hero-button:hover {
-  transform: scale(1.1);
-} */
-
-/* Hover v2 */
+/* Hover effects */
 .hero-button:hover {
   background: #ffe495;
 }
@@ -111,10 +106,7 @@
 /* HERO SIDE B ASSETS */
 .hero-blob1 {
   position: absolute;
-  /* left: -100px; */
-  /* top: 230px; */
   width: 30%;
-  /* animation: floatNearOrigin 8s infinite ease-in-out; */
   transition: transform 0.2s ease-out;
   z-index: 2;
 }
@@ -122,9 +114,7 @@
 .hero-blob2 {
   position: absolute;
   right: -20px;
-  /* top: 0px; */
   width: 12%;
-  /* animation: floatNearOrigin 8s infinite ease-in-out; */
   transition: transform 0.2s ease-out;
   z-index: 2;
 }
@@ -135,7 +125,6 @@
   width: 23%;
   z-index: 2;
   left: 50px;
-  /* animation: floatNearOrigin 6s infinite ease-in-out; */
   transition: transform 0.2s ease-out;
 }
 
@@ -145,7 +134,6 @@
   width: 18%;
   z-index: 2;
   right: 100px;
-  /* animation: floatNearOrigin 7s infinite ease-in-out; */
   transition: transform 0.2s ease-out;
 }
 
@@ -153,7 +141,6 @@
   width: 100%;
   position: fixed;
   bottom: 0px;
-  /* transform: rotate(4deg); */
   z-index: 1;
 }
 
@@ -181,7 +168,6 @@
 
   .hero-blob1 {
     left: -70px;
-    /* width: 18%; */
   }
 
   .hero-EMBARK {
@@ -214,8 +200,9 @@
     width: 30%;
   }
 
+  /* KEEP THIS THE SAME AS SIDE A - Changed from 90vh to 80vh */
   .hero-title {
-    height: 90vh;
+    height: 80vh;
   }
 
   .hero-EMBARK {
@@ -239,16 +226,12 @@
   }
 
   .hero-character1 {
-    /* bottom: unset; */
     width: 35%;
-    /* transform: rotate(25deg); */
     left: -40px;
-    /* top: -30px; */
   }
 
   .hero-blob1 {
     top: unset;
-    /* bottom: 180px; */
     width: 40%;
   }
 
@@ -277,7 +260,6 @@
   }
 
   .hero-blob1 {
-    /* left: -120px; */
     bottom: 160px;
     width: 50%;
   }
@@ -289,7 +271,6 @@
   .hero-character1 {
     width: 45%;
     left: -40px;
-    /* top: -30px; */
   }
 
   .hero-EMBARK {
@@ -338,16 +319,14 @@
 
   .hero-blob1 {
     width: 70%;
-    /* left: -80px; */
   }
 
   .hero-character1 {
-    /* top: -10px; */
     left: -40px;
   }
 }
 
-/* FLOATING ANIMATION FROM READNOW */
+/* FLOATING ANIMATION */
 @keyframes floatNearOrigin {
   0% {
     transform: translateY(0) translateX(0);
@@ -375,8 +354,6 @@
 .fade-in-on-load {
   opacity: 0;
   transition: opacity 1s ease;
-  /* transform: translateY(20px); */
-  /* transition: opacity 0.8s ease, transform 0.8s ease; */
 }
 
 .fade-in-on-load.delay-1 {

--- a/styles/side-b/components/navbar.css
+++ b/styles/side-b/components/navbar.css
@@ -11,6 +11,7 @@
   background: #561487;
   box-shadow: 0px 10px 20px rgba(0, 0, 0, 0.25);
   padding: 25px 40px;
+  transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 .navbar-container {
@@ -160,8 +161,8 @@
   top: calc(100% + 12px);
   left: 50%;
   transform: translateX(-50%);
-  background: rgba(17, 3, 73, 0.95);
-  color: #fff5db;
+  background: #F05F7D;
+  color: #F3F3F3;
   padding: 8px 16px;
   border-radius: 100px;
   font-family: "Sora", sans-serif;
@@ -182,7 +183,7 @@
   left: 50%;
   transform: translateX(-50%);
   border: 6px solid transparent;
-  border-bottom-color: rgba(17, 3, 73, 0.95);
+  border-bottom-color: #F05F7D;
 }
 
 .toggle-switch-wrapper:hover .toggle-tooltip {
@@ -406,7 +407,7 @@
 
   .toggle-thumb {
     top: 7px;
-    left: 3px;
+    left: 9px;
     width: 28px;
     height: 28px;
   }
@@ -542,7 +543,7 @@
 
   .mobile-toggle .toggle-thumb {
     top: 6px;
-    left: 4px;
+    left: 8px;
     width: 24px;
     height: 24px;
     background: #f69b6c;

--- a/styles/side-b/components/readnow2.css
+++ b/styles/side-b/components/readnow2.css
@@ -92,11 +92,11 @@
   /* Text styles */
   font-family: "Poppins", sans-serif;
   font-style: normal;
-  font-weight: 400;
+  font-weight: 600;
   font-size: 22px;
   line-height: 33px;
   text-align: center;
-  color: #f3f3f3;
+  color: #F3F3F3;
   margin: 0;
   display: flex;
   align-items: center;

--- a/styles/side-b/pages/about-ad-astra.css
+++ b/styles/side-b/pages/about-ad-astra.css
@@ -11,7 +11,7 @@ body,
 html {
   margin: 0;
   padding: 0;
-  overflow: hidden;
+  overflow-x: hidden;
   width: 100%;
   height: 100%;
   zoom: reset;
@@ -23,9 +23,7 @@ html {
 
 /* MAIN CONTAINER & BACKGROUND */
 .about-ad-astra {
-  position: fixed;
-  top: 0;
-  left: 0;
+  position: relative;
   width: 100vw;
   height: 100vh;
   background: url("data:image/svg+xml,%3Csvg viewBox='0 0 1920 1080' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.3' numOctaves='3' stitchTiles='stitch'/%3E%3CfeComponentTransfer%3E%3CfeFuncA type='discrete' tableValues='0.2 0.3 0.4 0.5 0.6 0.7 0.8 0.9 1'/%3E%3C/feComponentTransfer%3E%3CfeColorMatrix type='saturate' values='1.8'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noiseFilter)' opacity='0.3'/%3E%3C/svg%3E"),
@@ -49,7 +47,7 @@ html {
   z-index: 10;
 }
 
-/* CARD */
+/* CARD COMPONENT */
 .about-card {
   position: relative;
   width: min(1112px, 95vw);
@@ -207,7 +205,7 @@ html {
   margin: 0 clamp(1px, 0.3vw, 1px);
 }
 
-/* NAV BTN */
+/* NAVIGATION BUTTONS */
 .nav-button {
   position: absolute;
   width: 56px;
@@ -300,18 +298,14 @@ html {
   transform: scale(0.9);
 }
 
-/* RESPONSIVE NOISE FILTER BGs */
+/* RESPONSIVE BREAKPOINTS */
 
 /* Mobile Phones (up to 480px) */
 @media (max-width: 480px) {
   .about-ad-astra {
-    background: url("data:image/svg+xml,%3Csvg viewBox='0 0 480 800' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='mobileNoiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.45' numOctaves='2' stitchTiles='stitch'/%3E%3CfeComponentTransfer%3E%3CfeFuncA type='discrete' tableValues='0.3 0.4 0.5 0.6 0.7 0.8 0.9 1'/%3E%3C/feComponentTransfer%3E%3CfeColorMatrix type='saturate' values='1.6'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23mobileNoiseFilter)' opacity='0.4'/%3E%3C/svg%3E"),
-      linear-gradient(180deg, #ff60d7 -37.5%, #110349 70.09%);
-    background-size: cover;
-    background-attachment: scroll;
     padding: 8px;
+    background-size: 100% 100%;
     background-position: center;
-    background-repeat: no-repeat;
   }
 
   .about-card {
@@ -427,8 +421,6 @@ html {
 /* Tablets (481px - 768px) */
 @media (min-width: 481px) and (max-width: 768px) {
   .about-ad-astra {
-    background: url("data:image/svg+xml,%3Csvg viewBox='0 0 1024 1024' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='tabletNoiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.35' numOctaves='2' stitchTiles='stitch'/%3E%3CfeComponentTransfer%3E%3CfeFuncA type='discrete' tableValues='0.25 0.35 0.45 0.55 0.65 0.75 0.85 0.95 1'/%3E%3C/feComponentTransfer%3E%3CfeColorMatrix type='saturate' values='1.7'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23tabletNoiseFilter)' opacity='0.35'/%3E%3C/svg%3E"),
-      linear-gradient(180deg, #ff60d7 -37.5%, #110349 70.09%);
     background-size: 100% 100%;
     background-position: center;
   }
@@ -538,12 +530,6 @@ html {
 
 /* Small Laptops (769px - 1024px) */
 @media (min-width: 769px) and (max-width: 1024px) {
-  .about-ad-astra {
-    background: url("data:image/svg+xml,%3Csvg viewBox='0 0 1024 768' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='laptopNoiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.32' numOctaves='3' stitchTiles='stitch'/%3E%3CfeComponentTransfer%3E%3CfeFuncA type='discrete' tableValues='0.2 0.3 0.4 0.5 0.6 0.7 0.8 0.9 1'/%3E%3C/feComponentTransfer%3E%3CfeColorMatrix type='saturate' values='1.75'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23laptopNoiseFilter)' opacity='0.32'/%3E%3C/svg%3E"),
-      linear-gradient(180deg, #ff60d7 -37.5%, #110349 70.09%);
-    background-size: 100% 100%;
-  }
-
   .about-card {
     width: 85vw;
     padding: 50px 35px;
@@ -598,12 +584,6 @@ html {
 
 /* Desktop (1025px - 1440px) */
 @media (min-width: 1025px) and (max-width: 1440px) {
-  .about-ad-astra {
-    background: url("data:image/svg+xml,%3Csvg viewBox='0 0 1440 900' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='desktopNoiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.3' numOctaves='3' stitchTiles='stitch'/%3E%3CfeComponentTransfer%3E%3CfeFuncA type='discrete' tableValues='0.2 0.3 0.4 0.5 0.6 0.7 0.8 0.9 1'/%3E%3C/feComponentTransfer%3E%3CfeColorMatrix type='saturate' values='1.8'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23desktopNoiseFilter)' opacity='0.3'/%3E%3C/svg%3E"),
-      linear-gradient(180deg, #ff60d7 -37.5%, #110349 70.09%);
-    background-size: 100% 100%;
-  }
-
   .about-card {
     width: 70vw;
     max-width: 850px;
@@ -651,12 +631,6 @@ html {
 
 /* Large Desktop (1441px - 1919px) */
 @media (min-width: 1441px) and (max-width: 1919px) {
-  .about-ad-astra {
-    background: url("data:image/svg+xml,%3Csvg viewBox='0 0 1920 1080' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='largeDesktopNoiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.28' numOctaves='3' stitchTiles='stitch'/%3E%3CfeComponentTransfer%3E%3CfeFuncA type='discrete' tableValues='0.2 0.3 0.4 0.5 0.6 0.7 0.8 0.9 1'/%3E%3C/feComponentTransfer%3E%3CfeColorMatrix type='saturate' values='1.8'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23largeDesktopNoiseFilter)' opacity='0.28'/%3E%3C/svg%3E"),
-      linear-gradient(180deg, #ff60d7 -37.5%, #110349 70.09%);
-    background-size: 100% 100%;
-  }
-
   .about-card {
     width: 950px;
     height: auto;
@@ -704,12 +678,6 @@ html {
 
 /* Ultra Wide (1920px - 2559px) */
 @media (min-width: 1920px) and (max-width: 2559px) {
-  .about-ad-astra {
-    background: url("data:image/svg+xml,%3Csvg viewBox='0 0 2560 1440' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='ultraWideNoiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.25' numOctaves='4' stitchTiles='stitch'/%3E%3CfeComponentTransfer%3E%3CfeFuncA type='discrete' tableValues='0.15 0.25 0.35 0.45 0.55 0.65 0.75 0.85 0.95 1'/%3E%3C/feComponentTransfer%3E%3CfeColorMatrix type='saturate' values='1.9'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23ultraWideNoiseFilter)' opacity='0.25'/%3E%3C/svg%3E"),
-      linear-gradient(180deg, #ff60d7 -37.5%, #110349 70.09%);
-    background-size: 100% 100%;
-  }
-
   .about-card {
     width: 1200px;
     height: 800px;
@@ -776,12 +744,6 @@ html {
 
 /* Extra Ultra Wide (2560px+) */
 @media (min-width: 2560px) {
-  .about-ad-astra {
-    background: url("data:image/svg+xml,%3Csvg viewBox='0 0 3840 2160' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='extraUltraWideNoiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.22' numOctaves='4' stitchTiles='stitch'/%3E%3CfeComponentTransfer%3E%3CfeFuncA type='discrete' tableValues='0.1 0.2 0.3 0.4 0.5 0.6 0.7 0.8 0.9 1'/%3E%3C/feComponentTransfer%3E%3CfeColorMatrix type='saturate' values='2.0'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23extraUltraWideNoiseFilter)' opacity='0.22'/%3E%3C/svg%3E"),
-      linear-gradient(180deg, #ff60d7 -37.5%, #110349 70.09%);
-    background-size: 100% 100%;
-  }
-
   .about-card {
     width: clamp(1800px, 55vw, 2000px);
     height: clamp(900px, 65vh, 1200px);
@@ -865,8 +827,6 @@ html {
 /* LANDSCAPE ORIENTATION */
 @media (orientation: landscape) and (max-height: 600px) {
   .about-ad-astra {
-    background: url("data:image/svg+xml,%3Csvg viewBox='0 0 800 600' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='landscapeNoiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.38' numOctaves='2' stitchTiles='stitch'/%3E%3CfeComponentTransfer%3E%3CfeFuncA type='discrete' tableValues='0.25 0.35 0.45 0.55 0.65 0.75 0.85 0.95 1'/%3E%3C/feComponentTransfer%3E%3CfeColorMatrix type='saturate' values='1.7'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23landscapeNoiseFilter)' opacity='0.35'/%3E%3C/svg%3E"),
-      linear-gradient(180deg, #ff60d7 -37.5%, #110349 70.09%);
     background-size: 100% 100%;
     background-position: center;
   }
@@ -946,186 +906,90 @@ html {
   }
 }
 
-/* ZOOM-AWARE RESPONSIVE NOISE FILTER BGs */
+@media (orientation: landscape) and (max-height: 600px) and (max-width: 768px) {
+  .left-button {
+    left: 50%;
+    top: auto;
+    bottom: clamp(-38px, -8vh, -30px);
+    transform: translateX(clamp(-32px, -7vw, -28px));
+  }
 
-/* Mobile Phones (up to 480px) */
-@media (max-width: 480px) {
-  .about-ad-astra {
-    background: url("data:image/svg+xml,%3Csvg viewBox='0 0 480 800' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='mobileNoiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.45' numOctaves='2' stitchTiles='stitch'/%3E%3CfeComponentTransfer%3E%3CfeFuncA type='discrete' tableValues='0.3 0.4 0.5 0.6 0.7 0.8 0.9 1'/%3E%3C/feComponentTransfer%3E%3CfeColorMatrix type='saturate' values='1.6'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23mobileNoiseFilter)' opacity='0.4'/%3E%3C/svg%3E"),
-      linear-gradient(180deg, #ff60d7 -37.5%, #110349 70.09%);
-    background-size: cover;
-    background-attachment: scroll;
-    padding: 8px;
-    background-position: center;
-    background-repeat: no-repeat;
+  .right-button {
+    right: 50%;
+    top: auto;
+    bottom: clamp(-38px, -8vh, -30px);
+    transform: translateX(clamp(28px, 7vw, 32px));
+  }
+
+  .about-card {
+    padding: clamp(8px, 1.8vh, 15px) clamp(12px, 2.5vw, 20px);
+  }
+
+  .about-description {
+    font-size: clamp(0.65rem, 1.8vw, 0.85rem);
   }
 }
 
-/* Zoom Level 110% */
-@media (max-width: 530px) and (min-width: 481px) {
-  .about-ad-astra {
-    background: url("data:image/svg+xml,%3Csvg viewBox='0 0 530 850' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='zoom110NoiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.42' numOctaves='2' stitchTiles='stitch'/%3E%3CfeComponentTransfer%3E%3CfeFuncA type='discrete' tableValues='0.3 0.4 0.5 0.6 0.7 0.8 0.9 1'/%3E%3C/feComponentTransfer%3E%3CfeColorMatrix type='saturate' values='1.65'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23zoom110NoiseFilter)' opacity='0.38'/%3E%3C/svg%3E"),
-      linear-gradient(180deg, #ff60d7 -37.5%, #110349 70.09%);
-    background-size: cover;
-    background-attachment: scroll;
-    background-position: center;
-    background-repeat: no-repeat;
+@media (orientation: landscape) and (max-height: 600px) and (min-width: 769px) {
+  .left-button {
+    left: -70px;
+    top: 50%;
+    transform: translateY(-50%);
+  }
+
+  .right-button {
+    right: -70px;
+    top: 50%;
+    transform: translateY(-50%);
   }
 }
 
-/* Zoom Level 125% */
-@media (max-width: 600px) and (min-width: 531px) {
-  .about-ad-astra {
-    background: url("data:image/svg+xml,%3Csvg viewBox='0 0 600 900' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='zoom125NoiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.40' numOctaves='2' stitchTiles='stitch'/%3E%3CfeComponentTransfer%3E%3CfeFuncA type='discrete' tableValues='0.28 0.38 0.48 0.58 0.68 0.78 0.88 0.98 1'/%3E%3C/feComponentTransfer%3E%3CfeColorMatrix type='saturate' values='1.68'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23zoom125NoiseFilter)' opacity='0.36'/%3E%3C/svg%3E"),
-      linear-gradient(180deg, #ff60d7 -37.5%, #110349 70.09%);
-    background-size: cover;
-    background-attachment: scroll;
-    background-position: center;
-    background-repeat: no-repeat;
+/* ACCESSIBILITY & PERFORMANCE */
+
+@media (prefers-contrast: high) {
+  .embark-number-title {
+    color: #ffffff;
+  }
+  .embark-number,
+  .embark-number-inline {
+    color: #ff9966;
   }
 }
 
-/* Zoom Level 133% */
-@media (max-width: 640px) and (min-width: 601px) {
-  .about-ad-astra {
-    background: url("data:image/svg+xml,%3Csvg viewBox='0 0 640 950' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='zoom133NoiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.38' numOctaves='2' stitchTiles='stitch'/%3E%3CfeComponentTransfer%3E%3CfeFuncA type='discrete' tableValues='0.28 0.38 0.48 0.58 0.68 0.78 0.88 0.98 1'/%3E%3C/feComponentTransfer%3E%3CfeColorMatrix type='saturate' values='1.7'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23zoom133NoiseFilter)' opacity='0.35'/%3E%3C/svg%3E"),
-      linear-gradient(180deg, #ff60d7 -37.5%, #110349 70.09%);
-    background-size: cover;
-    background-attachment: scroll;
-    background-position: center;
-    background-repeat: no-repeat;
+@media (prefers-reduced-motion: reduce) {
+  .embark-logo,
+  .embark-logo-small,
+  .embark-logo-title,
+  .content-slide,
+  .nav-button,
+  .nav-button-svg,
+  .dot-indicator {
+    transition: none;
   }
 }
 
-/* Zoom Level 150%  */
-@media (max-width: 720px) and (min-width: 641px) {
-  .about-ad-astra {
-    background: url("data:image/svg+xml,%3Csvg viewBox='0 0 720 1000' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='zoom150NoiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.36' numOctaves='2' stitchTiles='stitch'/%3E%3CfeComponentTransfer%3E%3CfeFuncA type='discrete' tableValues='0.26 0.36 0.46 0.56 0.66 0.76 0.86 0.96 1'/%3E%3C/feComponentTransfer%3E%3CfeColorMatrix type='saturate' values='1.72'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23zoom150NoiseFilter)' opacity='0.34'/%3E%3C/svg%3E"),
-      linear-gradient(180deg, #ff60d7 -37.5%, #110349 70.09%);
-    background-size: cover;
-    background-attachment: scroll;
-    background-position: center;
-    background-repeat: no-repeat;
+@media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) {
+  .noise-rectangle,
+  .embark-logo,
+  .embark-logo-small,
+  .embark-logo-title {
+    image-rendering: -webkit-optimize-contrast;
+    image-rendering: crisp-edges;
   }
 }
 
-/* Zoom Level 175% */
-@media (max-width: 850px) and (min-width: 721px) {
-  .about-ad-astra {
-    background: url("data:image/svg+xml,%3Csvg viewBox='0 0 850 1100' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='zoom175NoiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.34' numOctaves='2' stitchTiles='stitch'/%3E%3CfeComponentTransfer%3E%3CfeFuncA type='discrete' tableValues='0.25 0.35 0.45 0.55 0.65 0.75 0.85 0.95 1'/%3E%3C/feComponentTransfer%3E%3CfeColorMatrix type='saturate' values='1.74'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23zoom175NoiseFilter)' opacity='0.33'/%3E%3C/svg%3E"),
-      linear-gradient(180deg, #ff60d7 -37.5%, #110349 70.09%);
-    background-size: cover;
-    background-attachment: scroll;
-    background-position: center;
-    background-repeat: no-repeat;
+@media print {
+  .embark-logo,
+  .embark-logo-small,
+  .embark-logo-title {
+    height: 16px;
+    margin: 0 2px;
   }
-}
 
-/* Zoom Level 200% and higher */
-@media (max-width: 960px) and (min-width: 851px) {
-  .about-ad-astra {
-    background: url("data:image/svg+xml,%3Csvg viewBox='0 0 960 1200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='zoom200NoiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.32' numOctaves='3' stitchTiles='stitch'/%3E%3CfeComponentTransfer%3E%3CfeFuncA type='discrete' tableValues='0.24 0.34 0.44 0.54 0.64 0.74 0.84 0.94 1'/%3E%3C/feComponentTransfer%3E%3CfeColorMatrix type='saturate' values='1.76'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23zoom200NoiseFilter)' opacity='0.32'/%3E%3C/svg%3E"),
-      linear-gradient(180deg, #ff60d7 -37.5%, #110349 70.09%);
-    background-size: cover;
-    background-attachment: scroll;
-    background-position: center;
-    background-repeat: no-repeat;
-  }
-}
-
-/* Tablets (961px - 1100px) */
-@media (min-width: 961px) and (max-width: 1100px) {
-  .about-ad-astra {
-    background: url("data:image/svg+xml,%3Csvg viewBox='0 0 1100 1024' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='mediumZoomNoiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.30' numOctaves='3' stitchTiles='stitch'/%3E%3CfeComponentTransfer%3E%3CfeFuncA type='discrete' tableValues='0.22 0.32 0.42 0.52 0.62 0.72 0.82 0.92 1'/%3E%3C/feComponentTransfer%3E%3CfeColorMatrix type='saturate' values='1.78'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23mediumZoomNoiseFilter)' opacity='0.30'/%3E%3C/svg%3E"),
-      linear-gradient(180deg, #ff60d7 -37.5%, #110349 70.09%);
-    background-size: cover;
-    background-attachment: fixed;
-    background-position: center;
-    background-repeat: no-repeat;
-  }
-}
-
-/* Desktop Zoom 110% */
-@media (min-width: 1101px) and (max-width: 1300px) {
-  .about-ad-astra {
-    background: url("data:image/svg+xml,%3Csvg viewBox='0 0 1300 900' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='desktopZoom110NoiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.29' numOctaves='3' stitchTiles='stitch'/%3E%3CfeComponentTransfer%3E%3CfeFuncA type='discrete' tableValues='0.20 0.30 0.40 0.50 0.60 0.70 0.80 0.90 1'/%3E%3C/feComponentTransfer%3E%3CfeColorMatrix type='saturate' values='1.8'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23desktopZoom110NoiseFilter)' opacity='0.29'/%3E%3C/svg%3E"),
-      linear-gradient(180deg, #ff60d7 -37.5%, #110349 70.09%);
-    background-size: cover;
-    background-attachment: fixed;
-    background-position: center;
-    background-repeat: no-repeat;
-  }
-}
-
-/* Desktop Zoom 125% */
-@media (min-width: 1301px) and (max-width: 1500px) {
-  .about-ad-astra {
-    background: url("data:image/svg+xml,%3Csvg viewBox='0 0 1500 950' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='desktopZoom125NoiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.28' numOctaves='3' stitchTiles='stitch'/%3E%3CfeComponentTransfer%3E%3CfeFuncA type='discrete' tableValues='0.19 0.29 0.39 0.49 0.59 0.69 0.79 0.89 0.99 1'/%3E%3C/feComponentTransfer%3E%3CfeColorMatrix type='saturate' values='1.82'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23desktopZoom125NoiseFilter)' opacity='0.28'/%3E%3C/svg%3E"),
-      linear-gradient(180deg, #ff60d7 -37.5%, #110349 70.09%);
-    background-size: cover;
-    background-attachment: fixed;
-    background-position: center;
-    background-repeat: no-repeat;
-  }
-}
-
-/* Desktop Zoom 133% */
-@media (min-width: 1501px) and (max-width: 1650px) {
-  .about-ad-astra {
-    background: url("data:image/svg+xml,%3Csvg viewBox='0 0 1650 1000' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='desktopZoom133NoiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.27' numOctaves='3' stitchTiles='stitch'/%3E%3CfeComponentTransfer%3E%3CfeFuncA type='discrete' tableValues='0.18 0.28 0.38 0.48 0.58 0.68 0.78 0.88 0.98 1'/%3E%3C/feComponentTransfer%3E%3CfeColorMatrix type='saturate' values='1.84'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23desktopZoom133NoiseFilter)' opacity='0.27'/%3E%3C/svg%3E"),
-      linear-gradient(180deg, #ff60d7 -37.5%, #110349 70.09%);
-    background-size: cover;
-    background-attachment: fixed;
-    background-position: center;
-    background-repeat: no-repeat;
-  }
-}
-
-/* Desktop Zoom 150%  */
-@media (min-width: 1651px) and (max-width: 1900px) {
-  .about-ad-astra {
-    background: url("data:image/svg+xml,%3Csvg viewBox='0 0 1900 1100' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='desktopZoom150NoiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.26' numOctaves='3' stitchTiles='stitch'/%3E%3CfeComponentTransfer%3E%3CfeFuncA type='discrete' tableValues='0.17 0.27 0.37 0.47 0.57 0.67 0.77 0.87 0.97 1'/%3E%3C/feComponentTransfer%3E%3CfeColorMatrix type='saturate' values='1.86'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23desktopZoom150NoiseFilter)' opacity='0.26'/%3E%3C/svg%3E"),
-      linear-gradient(180deg, #ff60d7 -37.5%, #110349 70.09%);
-    background-size: cover;
-    background-attachment: fixed;
-    background-position: center;
-    background-repeat: no-repeat;
-  }
-}
-
-/* Desktop Zoom 175% */
-@media (min-width: 1901px) and (max-width: 2200px) {
-  .about-ad-astra {
-    background: url("data:image/svg+xml,%3Csvg viewBox='0 0 2200 1200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='desktopZoom175NoiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.25' numOctaves='4' stitchTiles='stitch'/%3E%3CfeComponentTransfer%3E%3CfeFuncA type='discrete' tableValues='0.16 0.26 0.36 0.46 0.56 0.66 0.76 0.86 0.96 1'/%3E%3C/feComponentTransfer%3E%3CfeColorMatrix type='saturate' values='1.88'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23desktopZoom175NoiseFilter)' opacity='0.25'/%3E%3C/svg%3E"),
-      linear-gradient(180deg, #ff60d7 -37.5%, #110349 70.09%);
-    background-size: cover;
-    background-attachment: fixed;
-    background-position: center;
-    background-repeat: no-repeat;
-  }
-}
-
-/* Ultra Wide and Very High Zoom Levels */
-@media (min-width: 2201px) and (max-width: 2800px) {
-  .about-ad-astra {
-    background: url("data:image/svg+xml,%3Csvg viewBox='0 0 2800 1400' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='ultraZoomNoiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.23' numOctaves='4' stitchTiles='stitch'/%3E%3CfeComponentTransfer%3E%3CfeFuncA type='discrete' tableValues='0.15 0.25 0.35 0.45 0.55 0.65 0.75 0.85 0.95 1'/%3E%3C/feComponentTransfer%3E%3CfeColorMatrix type='saturate' values='1.9'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23ultraZoomNoiseFilter)' opacity='0.23'/%3E%3C/svg%3E"),
-      linear-gradient(180deg, #ff60d7 -37.5%, #110349 70.09%);
-    background-size: cover;
-    background-attachment: fixed;
-    background-position: center;
-    background-repeat: no-repeat;
-  }
-}
-
-/* Maximum Zoom Levels (200%+) */
-@media (min-width: 2801px) {
-  .about-ad-astra {
-    background: url("data:image/svg+xml,%3Csvg viewBox='0 0 3840 2160' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='maxZoomNoiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.21' numOctaves='4' stitchTiles='stitch'/%3E%3CfeComponentTransfer%3E%3CfeFuncA type='discrete' tableValues='0.14 0.24 0.34 0.44 0.54 0.64 0.74 0.84 0.94 1'/%3E%3C/feComponentTransfer%3E%3CfeColorMatrix type='saturate' values='1.95'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23maxZoomNoiseFilter)' opacity='0.21'/%3E%3C/svg%3E"),
-      linear-gradient(180deg, #ff60d7 -37.5%, #110349 70.09%);
-    background-size: cover;
-    background-attachment: fixed;
-    background-position: center;
-    background-repeat: no-repeat;
+  .embark-number-title,
+  .embark-number,
+  .embark-number-inline {
+    color: #000000 !important;
   }
 }
 
@@ -1237,7 +1101,6 @@ html {
   transform: translateY(-1px);
 }
 
-/* Positioning adjustments for hover state */
 .left-button:hover {
   transform: translateY(-50%) scale(1.15);
 }

--- a/styles/side-b/pages/about-decorative-assets.css
+++ b/styles/side-b/pages/about-decorative-assets.css
@@ -1,7 +1,7 @@
 /* (SIDE B) DESKTOP ASSETS */
 
 .left-frame-path {
-  position: fixed;
+  position: absolute;
   left: -50px;
   top: 25%;
   transform: translateY(-50%);
@@ -14,7 +14,7 @@
 }
 
 .right-frame-path {
-  position: fixed;
+  position: absolute;
   bottom: -50px;
   right: 0;
   width: auto;
@@ -28,7 +28,7 @@
 /* MOBILE DECORATIVE ASSETS */
 
 .mobile-bottom-assets {
-  position: fixed;
+  position: absolute;
   bottom: -200px;
   left: 0;
   width: 100vw;
@@ -48,7 +48,7 @@
 }
 
 .mobile-top-assets {
-  position: fixed;
+  position: absolute;
   top: -100px;
   right: -30px;
   width: auto;
@@ -255,14 +255,14 @@
     height: 70vh;
     width: 100vw;
     bottom: -200px;
-    position: fixed;
+    position: absolute;
   }
 
   .mobile-top-assets {
     display: block;
     height: 40vh;
     top: -100px;
-    position: fixed;
+    position: absolute;
   }
 }
 
@@ -272,14 +272,14 @@
     height: 60vh;
     width: 100vw;
     bottom: -180px;
-    position: fixed;
+    position: absolute;
   }
 
   .mobile-top-assets {
     display: block;
     height: 28vh;
     top: -60px;
-    position: fixed;
+    position: absolute;
   }
 }
 

--- a/styles/side-b/pages/credits.css
+++ b/styles/side-b/pages/credits.css
@@ -33,7 +33,7 @@ html {
 }
 
 .credits-ad-astra {
-  position: fixed;
+  position: relative;
   top: 0;
   left: 0;
   width: 100vw;

--- a/styles/side-b/pages/pre-readnow-assets.css
+++ b/styles/side-b/pages/pre-readnow-assets.css
@@ -75,7 +75,7 @@
 
 .right-face {
   top: clamp(10px, 5vh, 80px);
-  right: clamp(80px, 12vw, 200px);
+  right: clamp(180px, 24vw, 360px);
   width: clamp(180px, 26vw, 400px);
   height: auto;
   z-index: 1;
@@ -421,7 +421,7 @@
 
   .right-face {
     top: clamp(15px, 4vh, 50px);
-    right: clamp(-3px, 4vw, 10px);
+    right: clamp(-10px, 10vw, 25px);
     width: clamp(190px, 24vw, 270px);
   }
 
@@ -460,7 +460,7 @@
 
   .right-face {
     top: clamp(15px, 4vh, 50px);
-    right: clamp(-3px, 4vw, 10px);
+    right: clamp(-10px, 10vw, 25px);
     width: clamp(320px, 26vw, 200px);
   }
 

--- a/styles/side-b/pages/pre-readnow.css
+++ b/styles/side-b/pages/pre-readnow.css
@@ -11,7 +11,7 @@ body,
 html {
   margin: 0;
   padding: 0;
-  overflow: hidden;
+  overflow-x: hidden;
   width: 100%;
   height: 100%;
   zoom: reset;
@@ -23,15 +23,13 @@ html {
 
 /* MAIN CONTAINER & BACKGROUND */
 .pre-readnow {
-  position: fixed;
-  top: 0;
-  left: 0;
+  position: relative;
   width: 100vw;
   height: 100vh;
   background: url("data:image/svg+xml,%3Csvg viewBox='0 0 1920 1080' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.3' numOctaves='3' stitchTiles='stitch'/%3E%3CfeComponentTransfer%3E%3CfeFuncA type='discrete' tableValues='0.2 0.3 0.4 0.5 0.6 0.7 0.8 0.9 1'/%3E%3C/feComponentTransfer%3E%3CfeColorMatrix type='saturate' values='1.8'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noiseFilter)' opacity='0.3'/%3E%3C/svg%3E"),
     linear-gradient(180deg, #110349 30%, #402c89 100%);
   background-size: 100% 100%;
-  background-attachment: fixed;
+  background-attachment: absolute;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -91,7 +89,7 @@ html {
   margin-top: clamp(0px, 1vw, 10px);
 }
 
-/* RESPONSIVE NOISE FILTER BGs */
+/* RESPONSIVE BREAKPOINTS */
 
 /* Mobile Phones (up to 480px) */
 @media (max-width: 480px) {
@@ -99,7 +97,6 @@ html {
     background: url("data:image/svg+xml,%3Csvg viewBox='0 0 480 800' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='mobileNoiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.45' numOctaves='2' stitchTiles='stitch'/%3E%3CfeComponentTransfer%3E%3CfeFuncA type='discrete' tableValues='0.3 0.4 0.5 0.6 0.7 0.8 0.9 1'/%3E%3C/feComponentTransfer%3E%3CfeColorMatrix type='saturate' values='1.6'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23mobileNoiseFilter)' opacity='0.4'/%3E%3C/svg%3E"),
       linear-gradient(180deg, #110349 30%, #402c89 100%);
     background-size: cover;
-    background-attachment: scroll;
     padding: 10px;
     background-position: center;
     background-repeat: no-repeat;
@@ -240,10 +237,6 @@ html {
 
   .content-container {
     padding: clamp(80px, 8vh, 120px) clamp(60px, 4vw, 100px);
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
     width: auto;
     height: auto;
     max-width: 90vw;
@@ -314,230 +307,11 @@ html {
   }
 }
 
-/* ZOOM-AWARE RESPONSIVE NOISE FILTER BGs */
-
-/* Mobile Phones (up to 480px) */
-@media (max-width: 480px) {
-  .pre-readnow {
-    background: url("data:image/svg+xml,%3Csvg viewBox='0 0 480 800' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='mobileNoiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.45' numOctaves='2' stitchTiles='stitch'/%3E%3CfeComponentTransfer%3E%3CfeFuncA type='discrete' tableValues='0.3 0.4 0.5 0.6 0.7 0.8 0.9 1'/%3E%3C/feComponentTransfer%3E%3CfeColorMatrix type='saturate' values='1.6'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23mobileNoiseFilter)' opacity='0.4'/%3E%3C/svg%3E"),
-      linear-gradient(180deg, #110349 50%, #402c89 100%);
-    background-size: cover;
-    background-attachment: scroll;
-    padding: 10px;
-    background-position: center;
-    background-repeat: no-repeat;
-  }
-}
-
-/* Zoom Level 110% */
-@media (max-width: 530px) and (min-width: 481px) {
-  .pre-readnow {
-    background: url("data:image/svg+xml,%3Csvg viewBox='0 0 530 850' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='zoom110NoiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.42' numOctaves='2' stitchTiles='stitch'/%3E%3CfeComponentTransfer%3E%3CfeFuncA type='discrete' tableValues='0.3 0.4 0.5 0.6 0.7 0.8 0.9 1'/%3E%3C/feComponentTransfer%3E%3CfeColorMatrix type='saturate' values='1.65'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23zoom110NoiseFilter)' opacity='0.38'/%3E%3C/svg%3E"),
-      linear-gradient(180deg, #110349 30%, #402c89 100%);
-    background-size: cover;
-    background-attachment: scroll;
-    background-position: center;
-    background-repeat: no-repeat;
-  }
-}
-
-/* Zoom Level 125% */
-@media (max-width: 600px) and (min-width: 531px) {
-  .pre-readnow {
-    background: url("data:image/svg+xml,%3Csvg viewBox='0 0 600 900' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='zoom125NoiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.40' numOctaves='2' stitchTiles='stitch'/%3E%3CfeComponentTransfer%3E%3CfeFuncA type='discrete' tableValues='0.28 0.38 0.48 0.58 0.68 0.78 0.88 0.98 1'/%3E%3C/feComponentTransfer%3E%3CfeColorMatrix type='saturate' values='1.68'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23zoom125NoiseFilter)' opacity='0.36'/%3E%3C/svg%3E"),
-      linear-gradient(180deg, #110349 30%, #402c89 100%);
-    background-size: cover;
-    background-attachment: scroll;
-    background-position: center;
-    background-repeat: no-repeat;
-  }
-}
-
-/* Zoom Level 133% */
-@media (max-width: 640px) and (min-width: 601px) {
-  .pre-readnow {
-    background: url("data:image/svg+xml,%3Csvg viewBox='0 0 640 950' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='zoom133NoiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.38' numOctaves='2' stitchTiles='stitch'/%3E%3CfeComponentTransfer%3E%3CfeFuncA type='discrete' tableValues='0.28 0.38 0.48 0.58 0.68 0.78 0.88 0.98 1'/%3E%3C/feComponentTransfer%3E%3CfeColorMatrix type='saturate' values='1.7'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23zoom133NoiseFilter)' opacity='0.35'/%3E%3C/svg%3E"),
-      linear-gradient(180deg, #110349 30%, #402c89 100%);
-    background-size: cover;
-    background-attachment: scroll;
-    background-position: center;
-    background-repeat: no-repeat;
-  }
-}
-
-/* Zoom Level 150%  */
-@media (max-width: 720px) and (min-width: 641px) {
-  .pre-readnow {
-    background: url("data:image/svg+xml,%3Csvg viewBox='0 0 720 1000' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='zoom150NoiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.36' numOctaves='2' stitchTiles='stitch'/%3E%3CfeComponentTransfer%3E%3CfeFuncA type='discrete' tableValues='0.26 0.36 0.46 0.56 0.66 0.76 0.86 0.96 1'/%3E%3C/feComponentTransfer%3E%3CfeColorMatrix type='saturate' values='1.72'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23zoom150NoiseFilter)' opacity='0.34'/%3E%3C/svg%3E"),
-      linear-gradient(180deg, #110349 30%, #402c89 100%);
-    background-size: cover;
-    background-attachment: scroll;
-    background-position: center;
-    background-repeat: no-repeat;
-  }
-}
-
-/* Zoom Level 175% */
-@media (max-width: 850px) and (min-width: 721px) {
-  .pre-readnow {
-    background: url("data:image/svg+xml,%3Csvg viewBox='0 0 850 1100' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='zoom175NoiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.34' numOctaves='2' stitchTiles='stitch'/%3E%3CfeComponentTransfer%3E%3CfeFuncA type='discrete' tableValues='0.25 0.35 0.45 0.55 0.65 0.75 0.85 0.95 1'/%3E%3C/feComponentTransfer%3E%3CfeColorMatrix type='saturate' values='1.74'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23zoom175NoiseFilter)' opacity='0.33'/%3E%3C/svg%3E"),
-      linear-gradient(180deg, #110349 30%, #402c89 100%);
-    background-size: cover;
-    background-attachment: scroll;
-    background-position: center;
-    background-repeat: no-repeat;
-  }
-}
-
-/* Zoom Level 200% and higher */
-@media (max-width: 960px) and (min-width: 851px) {
-  .pre-readnow {
-    background: url("data:image/svg+xml,%3Csvg viewBox='0 0 960 1200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='zoom200NoiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.32' numOctaves='3' stitchTiles='stitch'/%3E%3CfeComponentTransfer%3E%3CfeFuncA type='discrete' tableValues='0.24 0.34 0.44 0.54 0.64 0.74 0.84 0.94 1'/%3E%3C/feComponentTransfer%3E%3CfeColorMatrix type='saturate' values='1.76'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23zoom200NoiseFilter)' opacity='0.32'/%3E%3C/svg%3E"),
-      linear-gradient(180deg, #110349 30%, #402c89 100%);
-    background-size: cover;
-    background-attachment: scroll;
-    background-position: center;
-    background-repeat: no-repeat;
-  }
-}
-
-/* Tablets (961px - 1100px) */
-@media (min-width: 961px) and (max-width: 1100px) {
-  .pre-readnow {
-    background: url("data:image/svg+xml,%3Csvg viewBox='0 0 1100 1024' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='mediumZoomNoiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.30' numOctaves='3' stitchTiles='stitch'/%3E%3CfeComponentTransfer%3E%3CfeFuncA type='discrete' tableValues='0.22 0.32 0.42 0.52 0.62 0.72 0.82 0.92 1'/%3E%3C/feComponentTransfer%3E%3CfeColorMatrix type='saturate' values='1.78'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23mediumZoomNoiseFilter)' opacity='0.30'/%3E%3C/svg%3E"),
-      linear-gradient(180deg, #110349 30%, #402c89 100%);
-    background-size: cover;
-    background-attachment: fixed;
-    background-position: center;
-    background-repeat: no-repeat;
-  }
-}
-
-/* Desktop Zoom 110% */
-@media (min-width: 1101px) and (max-width: 1300px) {
-  .pre-readnow {
-    background: url("data:image/svg+xml,%3Csvg viewBox='0 0 1300 900' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='desktopZoom110NoiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.29' numOctaves='3' stitchTiles='stitch'/%3E%3CfeComponentTransfer%3E%3CfeFuncA type='discrete' tableValues='0.20 0.30 0.40 0.50 0.60 0.70 0.80 0.90 1'/%3E%3C/feComponentTransfer%3E%3CfeColorMatrix type='saturate' values='1.8'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23desktopZoom110NoiseFilter)' opacity='0.29'/%3E%3C/svg%3E"),
-      linear-gradient(180deg, #110349 30%, #402c89 100%);
-    background-size: cover;
-    background-attachment: fixed;
-    background-position: center;
-    background-repeat: no-repeat;
-  }
-}
-
-/* Desktop Zoom 125% */
-@media (min-width: 1301px) and (max-width: 1500px) {
-  .pre-readnow {
-    background: url("data:image/svg+xml,%3Csvg viewBox='0 0 1500 950' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='desktopZoom125NoiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.28' numOctaves='3' stitchTiles='stitch'/%3E%3CfeComponentTransfer%3E%3CfeFuncA type='discrete' tableValues='0.19 0.29 0.39 0.49 0.59 0.69 0.79 0.89 0.99 1'/%3E%3C/feComponentTransfer%3E%3CfeColorMatrix type='saturate' values='1.82'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23desktopZoom125NoiseFilter)' opacity='0.28'/%3E%3C/svg%3E"),
-      linear-gradient(180deg, #110349 30%, #402c89 100%);
-    background-size: cover;
-    background-attachment: fixed;
-    background-position: center;
-    background-repeat: no-repeat;
-  }
-}
-
-/* Desktop Zoom 133% */
-@media (min-width: 1501px) and (max-width: 1650px) {
-  .pre-readnow {
-    background: url("data:image/svg+xml,%3Csvg viewBox='0 0 1650 1000' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='desktopZoom133NoiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.27' numOctaves='3' stitchTiles='stitch'/%3E%3CfeComponentTransfer%3E%3CfeFuncA type='discrete' tableValues='0.18 0.28 0.38 0.48 0.58 0.68 0.78 0.88 0.98 1'/%3E%3C/feComponentTransfer%3E%3CfeColorMatrix type='saturate' values='1.84'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23desktopZoom133NoiseFilter)' opacity='0.27'/%3E%3C/svg%3E"),
-      linear-gradient(180deg, #110349 30%, #402c89 100%);
-    background-size: cover;
-    background-attachment: fixed;
-    background-position: center;
-    background-repeat: no-repeat;
-  }
-}
-
-/* Desktop Zoom 150%  */
-@media (min-width: 1651px) and (max-width: 1900px) {
-  .pre-readnow {
-    background: url("data:image/svg+xml,%3Csvg viewBox='0 0 1900 1100' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='desktopZoom150NoiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.26' numOctaves='3' stitchTiles='stitch'/%3E%3CfeComponentTransfer%3E%3CfeFuncA type='discrete' tableValues='0.17 0.27 0.37 0.47 0.57 0.67 0.77 0.87 0.97 1'/%3E%3C/feComponentTransfer%3E%3CfeColorMatrix type='saturate' values='1.86'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23desktopZoom150NoiseFilter)' opacity='0.26'/%3E%3C/svg%3E"),
-      linear-gradient(180deg, #110349 30%, #402c89 100%);
-    background-size: cover;
-    background-attachment: fixed;
-    background-position: center;
-    background-repeat: no-repeat;
-  }
-}
-
-/* Desktop Zoom 175% */
-@media (min-width: 1901px) and (max-width: 2200px) {
-  .pre-readnow {
-    background: url("data:image/svg+xml,%3Csvg viewBox='0 0 2200 1200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='desktopZoom175NoiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.25' numOctaves='4' stitchTiles='stitch'/%3E%3CfeComponentTransfer%3E%3CfeFuncA type='discrete' tableValues='0.16 0.26 0.36 0.46 0.56 0.66 0.76 0.86 0.96 1'/%3E%3C/feComponentTransfer%3E%3CfeColorMatrix type='saturate' values='1.88'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23desktopZoom175NoiseFilter)' opacity='0.25'/%3E%3C/svg%3E"),
-      linear-gradient(180deg, #110349 30%, #402c89 100%);
-    background-size: cover;
-    background-attachment: fixed;
-    background-position: center;
-    background-repeat: no-repeat;
-  }
-}
-
-/* Ultra Wide and Very High Zoom Levels */
-@media (min-width: 2201px) and (max-width: 2800px) {
-  .pre-readnow {
-    background: url("data:image/svg+xml,%3Csvg viewBox='0 0 2800 1400' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='ultraZoomNoiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.23' numOctaves='4' stitchTiles='stitch'/%3E%3CfeComponentTransfer%3E%3CfeFuncA type='discrete' tableValues='0.15 0.25 0.35 0.45 0.55 0.65 0.75 0.85 0.95 1'/%3E%3C/feComponentTransfer%3E%3CfeColorMatrix type='saturate' values='1.9'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23ultraZoomNoiseFilter)' opacity='0.23'/%3E%3C/svg%3E"),
-      linear-gradient(180deg, #110349 30%, #402c89 100%);
-    background-size: cover;
-    background-attachment: fixed;
-    background-position: center;
-    background-repeat: no-repeat;
-  }
-}
-
-/* Maximum Zoom Levels (200%+) */
-@media (min-width: 2801px) and (max-width: 3840px) {
-  .pre-readnow {
-    background: url("data:image/svg+xml,%3Csvg viewBox='0 0 3840 2160' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='maxZoomNoiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.21' numOctaves='4' stitchTiles='stitch'/%3E%3CfeComponentTransfer%3E%3CfeFuncA type='discrete' tableValues='0.14 0.24 0.34 0.44 0.54 0.64 0.74 0.84 0.94 1'/%3E%3C/feComponentTransfer%3E%3CfeColorMatrix type='saturate' values='1.95'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23maxZoomNoiseFilter)' opacity='0.21'/%3E%3C/svg%3E"),
-      linear-gradient(180deg, #110349 30%, #402c89 100%);
-    background-size: cover;
-    background-attachment: fixed;
-    background-position: center;
-    background-repeat: no-repeat;
-  }
-}
-
-/* Zoom Level 300% */
-@media (min-width: 3841px) and (max-width: 4800px) {
-  .pre-readnow {
-    background: url("data:image/svg+xml,%3Csvg viewBox='0 0 4800 2700' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='zoom300NoiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.19' numOctaves='4' stitchTiles='stitch'/%3E%3CfeComponentTransfer%3E%3CfeFuncA type='discrete' tableValues='0.12 0.22 0.32 0.42 0.52 0.62 0.72 0.82 0.92 1'/%3E%3C/feComponentTransfer%3E%3CfeColorMatrix type='saturate' values='2.0'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23zoom300NoiseFilter)' opacity='0.19'/%3E%3C/svg%3E"),
-      linear-gradient(180deg, #110349 30%, #402c89 100%);
-    background-size: cover;
-    background-attachment: fixed;
-    background-position: center;
-    background-repeat: no-repeat;
-  }
-}
-
-/* Zoom Level 400% */
-@media (min-width: 4801px) and (max-width: 6400px) {
-  .pre-readnow {
-    background: url("data:image/svg+xml,%3Csvg viewBox='0 0 6400 3600' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='zoom400NoiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.17' numOctaves='5' stitchTiles='stitch'/%3E%3CfeComponentTransfer%3E%3CfeFuncA type='discrete' tableValues='0.10 0.20 0.30 0.40 0.50 0.60 0.70 0.80 0.90 1'/%3E%3C/feComponentTransfer%3E%3CfeColorMatrix type='saturate' values='2.1'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23zoom400NoiseFilter)' opacity='0.17'/%3E%3C/svg%3E"),
-      linear-gradient(180deg, #110349 30%, #402c89 100%);
-    background-size: cover;
-    background-attachment: fixed;
-    background-position: center;
-    background-repeat: no-repeat;
-  }
-}
-
-/* Zoom Level 500% and higher */
-@media (min-width: 6401px) {
-  .pre-readnow {
-    background: url("data:image/svg+xml,%3Csvg viewBox='0 0 8000 4500' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='zoom500NoiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.15' numOctaves='5' stitchTiles='stitch'/%3E%3CfeComponentTransfer%3E%3CfeFuncA type='discrete' tableValues='0.08 0.18 0.28 0.38 0.48 0.58 0.68 0.78 0.88 0.98 1'/%3E%3C/feComponentTransfer%3E%3CfeColorMatrix type='saturate' values='2.2'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23zoom500NoiseFilter)' opacity='0.15'/%3E%3C/svg%3E"),
-      linear-gradient(180deg, #110349 30%, #402c89 100%);
-    background-size: cover;
-    background-attachment: fixed;
-    background-position: center;
-    background-repeat: no-repeat;
-  }
-}
-
 /* ACCESSIBILITY & PERFORMANCE */
 
 @media (prefers-contrast: high) {
   .main-text {
-    color: #000000;
+    color: #ffffff;
   }
 }
 
@@ -575,27 +349,6 @@ html {
   animation: textFadeIn 1s cubic-bezier(0.25, 0.46, 0.45, 0.94) 0.6s forwards;
 }
 
-/* ANIMATION OVERRIDE FOR 2560px+ */
-@media (min-width: 2560px) {
-  .content-container {
-    opacity: 0;
-    transform: translate(-50%, -50%) translateY(30px);
-    animation: contentFadeInCentered 1.2s cubic-bezier(0.25, 0.46, 0.45, 0.94)
-      0.3s forwards;
-  }
-
-  @keyframes contentFadeInCentered {
-    0% {
-      opacity: 0;
-      transform: translate(-50%, -50%) translateY(30px);
-    }
-    100% {
-      opacity: 1;
-      transform: translate(-50%, -50%) translateY(0);
-    }
-  }
-}
-
 /* Entry animation keyframes */
 @keyframes contentFadeIn {
   0% {
@@ -625,12 +378,7 @@ html {
   .main-text {
     animation: none !important;
     opacity: 1 !important;
-  }
-
-  @media (min-width: 2560px) {
-    .content-container {
-      transform: translate(-50%, -50%) !important;
-    }
+    transform: none !important;
   }
 }
 
@@ -673,10 +421,6 @@ html {
 /* EXTRA WIDE SCREENS IN LANDSCAPE */
 @media (min-width: 3840px) {
   .content-container {
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
     width: auto;
     height: auto;
     max-width: 85vw;
@@ -688,27 +432,5 @@ html {
     line-height: clamp(10rem, 6.5vw, 17rem);
     margin: 0 auto;
     text-align: center;
-  }
-
-  .content-container {
-    animation: contentFadeInCentered 1.2s cubic-bezier(0.25, 0.46, 0.45, 0.94)
-      0.3s forwards;
-  }
-}
-
-/* ZOOM COMPATIBILITY FOR LARGE SCREENS */
-@media (min-width: 2560px) {
-  .pre-readnow {
-    min-width: 100vw;
-    min-height: 100vh;
-  }
-
-  .content-container {
-    position: fixed;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    width: fit-content;
-    height: fit-content;
   }
 }


### PR DESCRIPTION
**Adjustments for SIDE B Integrations in styles/css files:**
- hero, navbar, prev-embarks, readnow2, about-ad-astra, about-decorative-assets, credits, and pre-readnow

<img width="1150" height="241" alt="image" src="https://github.com/user-attachments/assets/6c3387e7-59e2-4508-aaba-06355a97aa1e" />
